### PR TITLE
e-core Backend Code Challenge

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 /.project
 /.classpath
+/target/

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,7 @@ COPY pom.xml .
 COPY spotless.xml .
 RUN mvn -e -B dependency:resolve dependency:resolve-plugins
 COPY src ./src
-RUN mvn -e -B clean package
+RUN mvn -e -B clean spotless:apply package
 
 FROM openjdk:11-slim AS RUNNER
 WORKDIR /app

--- a/src/main/java/com/ecore/roles/MessageUtil.java
+++ b/src/main/java/com/ecore/roles/MessageUtil.java
@@ -2,6 +2,10 @@ package com.ecore.roles;
 
 public class MessageUtil {
 
+    private MessageUtil() {
+        throw new IllegalStateException("Utility class");
+    }
+
     public static final String INVALID_S_OBJECT = "Invalid '%s' object";
     public static final String S_ALREADY_EXISTS = "%s already exists";
     public static final String S_NOT_FOUND = "%s not found";

--- a/src/main/java/com/ecore/roles/MessageUtil.java
+++ b/src/main/java/com/ecore/roles/MessageUtil.java
@@ -1,0 +1,13 @@
+package com.ecore.roles;
+
+public class MessageUtil {
+
+    public static final String INVALID_S_OBJECT = "Invalid '%s' object";
+    public static final String S_ALREADY_EXISTS = "%s already exists";
+    public static final String S_NOT_FOUND = "%s not found";
+    public static final String S_S_NOT_FOUND = "%s %s not found";
+    public static final String PROV_USR_DOESNT_BELONG_PROV_TEAM =
+            "The provided user doesn't belong to the provided team.";
+    public static final String BAD_REQUEST = "Bad Request";
+    public static final String NOT_FOUND = "Not Found";
+}

--- a/src/main/java/com/ecore/roles/exception/InvalidArgumentException.java
+++ b/src/main/java/com/ecore/roles/exception/InvalidArgumentException.java
@@ -1,7 +1,7 @@
 package com.ecore.roles.exception;
 
+import static com.ecore.roles.utils.MessageUtil.INVALID_S_OBJECT;
 import static java.lang.String.format;
-import static com.ecore.roles.MessageUtil.INVALID_S_OBJECT;
 
 public class InvalidArgumentException extends RuntimeException {
 

--- a/src/main/java/com/ecore/roles/exception/InvalidArgumentException.java
+++ b/src/main/java/com/ecore/roles/exception/InvalidArgumentException.java
@@ -2,9 +2,15 @@ package com.ecore.roles.exception;
 
 import static java.lang.String.format;
 
+import com.ecore.roles.model.Membership;
+
 public class InvalidArgumentException extends RuntimeException {
 
     public <T> InvalidArgumentException(Class<T> resource) {
         super(format("Invalid '%s' object", resource.getSimpleName()));
+    }
+
+    public InvalidArgumentException(Class<Membership> resource, String additionalInfo) {
+        super(format("Invalid '%s' object. " + additionalInfo, resource.getSimpleName()));
     }
 }

--- a/src/main/java/com/ecore/roles/exception/InvalidArgumentException.java
+++ b/src/main/java/com/ecore/roles/exception/InvalidArgumentException.java
@@ -10,6 +10,10 @@ public class InvalidArgumentException extends RuntimeException {
     }
 
     public <T> InvalidArgumentException(Class<T> resource, String additionalInfo) {
-        super(format(INVALID_S_OBJECT + ". " + additionalInfo, resource.getSimpleName()));
+        super(new StringBuilder()
+                .append(format(INVALID_S_OBJECT, resource.getSimpleName()))
+                .append(". ")
+                .append(additionalInfo)
+                .toString());
     }
 }

--- a/src/main/java/com/ecore/roles/exception/InvalidArgumentException.java
+++ b/src/main/java/com/ecore/roles/exception/InvalidArgumentException.java
@@ -1,16 +1,15 @@
 package com.ecore.roles.exception;
 
 import static java.lang.String.format;
-
-import com.ecore.roles.model.Membership;
+import static com.ecore.roles.MessageUtil.INVALID_S_OBJECT;
 
 public class InvalidArgumentException extends RuntimeException {
 
     public <T> InvalidArgumentException(Class<T> resource) {
-        super(format("Invalid '%s' object", resource.getSimpleName()));
+        super(format(INVALID_S_OBJECT, resource.getSimpleName()));
     }
 
-    public InvalidArgumentException(Class<Membership> resource, String additionalInfo) {
-        super(format("Invalid '%s' object. " + additionalInfo, resource.getSimpleName()));
+    public <T> InvalidArgumentException(Class<T> resource, String additionalInfo) {
+        super(format(INVALID_S_OBJECT + ". " + additionalInfo, resource.getSimpleName()));
     }
 }

--- a/src/main/java/com/ecore/roles/exception/ResourceExistsException.java
+++ b/src/main/java/com/ecore/roles/exception/ResourceExistsException.java
@@ -1,7 +1,7 @@
 package com.ecore.roles.exception;
 
+import static com.ecore.roles.utils.MessageUtil.S_ALREADY_EXISTS;
 import static java.lang.String.format;
-import static com.ecore.roles.MessageUtil.S_ALREADY_EXISTS;
 
 public class ResourceExistsException extends RuntimeException {
 

--- a/src/main/java/com/ecore/roles/exception/ResourceExistsException.java
+++ b/src/main/java/com/ecore/roles/exception/ResourceExistsException.java
@@ -1,10 +1,11 @@
 package com.ecore.roles.exception;
 
 import static java.lang.String.format;
+import static com.ecore.roles.MessageUtil.S_ALREADY_EXISTS;
 
 public class ResourceExistsException extends RuntimeException {
 
     public <T> ResourceExistsException(Class<T> resource) {
-        super(format("%s already exists", resource.getSimpleName()));
+        super(format(S_ALREADY_EXISTS, resource.getSimpleName()));
     }
 }

--- a/src/main/java/com/ecore/roles/exception/ResourceNotFoundException.java
+++ b/src/main/java/com/ecore/roles/exception/ResourceNotFoundException.java
@@ -2,10 +2,9 @@ package com.ecore.roles.exception;
 
 import java.util.UUID;
 
+import static com.ecore.roles.utils.MessageUtil.S_NOT_FOUND;
+import static com.ecore.roles.utils.MessageUtil.S_S_NOT_FOUND;
 import static java.lang.String.format;
-
-import static com.ecore.roles.MessageUtil.S_NOT_FOUND;
-import static com.ecore.roles.MessageUtil.S_S_NOT_FOUND;
 
 public class ResourceNotFoundException extends RuntimeException {
 

--- a/src/main/java/com/ecore/roles/exception/ResourceNotFoundException.java
+++ b/src/main/java/com/ecore/roles/exception/ResourceNotFoundException.java
@@ -4,9 +4,16 @@ import java.util.UUID;
 
 import static java.lang.String.format;
 
+import static com.ecore.roles.MessageUtil.S_NOT_FOUND;
+import static com.ecore.roles.MessageUtil.S_S_NOT_FOUND;
+
 public class ResourceNotFoundException extends RuntimeException {
 
     public <T> ResourceNotFoundException(Class<T> resource, UUID id) {
-        super(format("%s %s not found", resource.getSimpleName(), id));
+        super(format(S_S_NOT_FOUND, resource.getSimpleName(), id));
+    }
+
+    public <T> ResourceNotFoundException(Class<T> resource) {
+        super(format(S_NOT_FOUND, resource.getSimpleName()));
     }
 }

--- a/src/main/java/com/ecore/roles/model/Membership.java
+++ b/src/main/java/com/ecore/roles/model/Membership.java
@@ -17,7 +17,7 @@ import java.util.UUID;
 @Setter
 @Builder
 @Entity
-@Table(uniqueConstraints = @UniqueConstraint(columnNames = {"team_id", "user_id"}))
+@Table(uniqueConstraints = @UniqueConstraint(columnNames = {"role_id", "team_id", "user_id"}))
 public class Membership {
 
     @Id

--- a/src/main/java/com/ecore/roles/repository/MembershipRepository.java
+++ b/src/main/java/com/ecore/roles/repository/MembershipRepository.java
@@ -11,7 +11,9 @@ import java.util.UUID;
 @Repository
 public interface MembershipRepository extends JpaRepository<Membership, UUID> {
 
-    Optional<Membership> findByUserIdAndTeamId(UUID userId, UUID teamId);
+    Optional<Membership> findByRoleIdAndUserIdAndTeamId(UUID roleId, UUID userId, UUID teamId);
+
+    List<Membership> findByUserIdAndTeamId(UUID userId, UUID teamId);
 
     List<Membership> findByRoleId(UUID roleId);
 }

--- a/src/main/java/com/ecore/roles/service/RolesService.java
+++ b/src/main/java/com/ecore/roles/service/RolesService.java
@@ -7,10 +7,10 @@ import java.util.UUID;
 
 public interface RolesService {
 
-    Role CreateRole(Role role);
+    Role createRole(Role role);
 
-    Role GetRole(UUID id);
+    Role getRole(UUID id);
 
-    List<Role> GetRoles();
+    List<Role> getRoles();
 
 }

--- a/src/main/java/com/ecore/roles/service/RolesService.java
+++ b/src/main/java/com/ecore/roles/service/RolesService.java
@@ -1,6 +1,7 @@
 package com.ecore.roles.service;
 
 import com.ecore.roles.model.Role;
+import com.ecore.roles.web.dto.RoleDto;
 
 import java.util.List;
 import java.util.UUID;
@@ -12,5 +13,7 @@ public interface RolesService {
     Role getRole(UUID id);
 
     List<Role> getRoles();
+
+    List<RoleDto> getRoles(UUID userId, UUID teamId);
 
 }

--- a/src/main/java/com/ecore/roles/service/TeamsService.java
+++ b/src/main/java/com/ecore/roles/service/TeamsService.java
@@ -1,6 +1,7 @@
 package com.ecore.roles.service;
 
 import com.ecore.roles.client.model.Team;
+import com.ecore.roles.exception.ResourceNotFoundException;
 
 import java.util.List;
 import java.util.UUID;
@@ -10,4 +11,14 @@ public interface TeamsService {
     Team getTeam(UUID id);
 
     List<Team> getTeams();
+
+    /**
+     * Checks if given userId is either a team lead or member of the team having id equals teamId.
+     * 
+     * @param teamId Id of team to check.
+     * @param userId Id of user to check.
+     * @return true if user is member or team lead, false otherwise.
+     * @throws ResourceNotFoundException if team with given Id does not exist.
+     */
+    boolean isMemberOfTeam(UUID teamId, UUID userId);
 }

--- a/src/main/java/com/ecore/roles/service/impl/MembershipsServiceImpl.java
+++ b/src/main/java/com/ecore/roles/service/impl/MembershipsServiceImpl.java
@@ -18,8 +18,8 @@ import org.springframework.stereotype.Service;
 import java.util.List;
 import java.util.UUID;
 
+import static com.ecore.roles.utils.MessageUtil.PROV_USR_DOESNT_BELONG_PROV_TEAM;
 import static java.util.Optional.ofNullable;
-import static com.ecore.roles.MessageUtil.PROV_USR_DOESNT_BELONG_PROV_TEAM;
 
 @Log4j2
 @Service

--- a/src/main/java/com/ecore/roles/service/impl/MembershipsServiceImpl.java
+++ b/src/main/java/com/ecore/roles/service/impl/MembershipsServiceImpl.java
@@ -50,7 +50,9 @@ public class MembershipsServiceImpl implements MembershipsService {
             throw new ResourceExistsException(Membership.class);
         }
 
-        roleRepository.findById(roleId).orElseThrow(() -> new ResourceNotFoundException(Role.class, roleId));
+        if (roleRepository.findById(roleId).isEmpty()) {
+            throw new ResourceNotFoundException(Role.class, roleId);
+        }
 
         if (!teamsService.isMemberOfTeam(m.getTeamId(), m.getUserId())) {
             throw new InvalidArgumentException(Membership.class,

--- a/src/main/java/com/ecore/roles/service/impl/MembershipsServiceImpl.java
+++ b/src/main/java/com/ecore/roles/service/impl/MembershipsServiceImpl.java
@@ -19,6 +19,7 @@ import java.util.List;
 import java.util.UUID;
 
 import static java.util.Optional.ofNullable;
+import static com.ecore.roles.MessageUtil.PROV_USR_DOESNT_BELONG_PROV_TEAM;
 
 @Log4j2
 @Service
@@ -53,7 +54,7 @@ public class MembershipsServiceImpl implements MembershipsService {
 
         if (!teamsService.isMemberOfTeam(m.getTeamId(), m.getUserId())) {
             throw new InvalidArgumentException(Membership.class,
-                    "The provided user doesn't belong to the provided team.");
+                    PROV_USR_DOESNT_BELONG_PROV_TEAM);
         }
 
         return membershipRepository.save(m);

--- a/src/main/java/com/ecore/roles/service/impl/MembershipsServiceImpl.java
+++ b/src/main/java/com/ecore/roles/service/impl/MembershipsServiceImpl.java
@@ -8,6 +8,8 @@ import com.ecore.roles.model.Role;
 import com.ecore.roles.repository.MembershipRepository;
 import com.ecore.roles.repository.RoleRepository;
 import com.ecore.roles.service.MembershipsService;
+import com.ecore.roles.service.TeamsService;
+
 import lombok.NonNull;
 import lombok.extern.log4j.Log4j2;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -24,13 +26,16 @@ public class MembershipsServiceImpl implements MembershipsService {
 
     private final MembershipRepository membershipRepository;
     private final RoleRepository roleRepository;
+    private final TeamsService teamsService;
 
     @Autowired
     public MembershipsServiceImpl(
             MembershipRepository membershipRepository,
-            RoleRepository roleRepository) {
+            RoleRepository roleRepository,
+            TeamsService teamsService) {
         this.membershipRepository = membershipRepository;
         this.roleRepository = roleRepository;
+        this.teamsService = teamsService;
     }
 
     @Override
@@ -45,6 +50,12 @@ public class MembershipsServiceImpl implements MembershipsService {
         }
 
         roleRepository.findById(roleId).orElseThrow(() -> new ResourceNotFoundException(Role.class, roleId));
+
+        if (!teamsService.isMemberOfTeam(m.getTeamId(), m.getUserId())) {
+            throw new InvalidArgumentException(Membership.class,
+                    "The provided user doesn't belong to the provided team.");
+        }
+
         return membershipRepository.save(m);
     }
 

--- a/src/main/java/com/ecore/roles/service/impl/MembershipsServiceImpl.java
+++ b/src/main/java/com/ecore/roles/service/impl/MembershipsServiceImpl.java
@@ -44,7 +44,7 @@ public class MembershipsServiceImpl implements MembershipsService {
         UUID roleId = ofNullable(m.getRole()).map(Role::getId)
                 .orElseThrow(() -> new InvalidArgumentException(Role.class));
 
-        if (membershipRepository.findByUserIdAndTeamId(m.getUserId(), m.getTeamId())
+        if (membershipRepository.findByRoleIdAndUserIdAndTeamId(roleId, m.getUserId(), m.getTeamId())
                 .isPresent()) {
             throw new ResourceExistsException(Membership.class);
         }

--- a/src/main/java/com/ecore/roles/service/impl/RolesServiceImpl.java
+++ b/src/main/java/com/ecore/roles/service/impl/RolesServiceImpl.java
@@ -36,7 +36,7 @@ public class RolesServiceImpl implements RolesService {
     }
 
     @Override
-    public Role CreateRole(@NonNull Role r) {
+    public Role createRole(@NonNull Role r) {
         if (roleRepository.findByName(r.getName()).isPresent()) {
             throw new ResourceExistsException(Role.class);
         }
@@ -44,13 +44,13 @@ public class RolesServiceImpl implements RolesService {
     }
 
     @Override
-    public Role GetRole(@NonNull UUID rid) {
+    public Role getRole(@NonNull UUID rid) {
         return roleRepository.findById(rid)
                 .orElseThrow(() -> new ResourceNotFoundException(Role.class, rid));
     }
 
     @Override
-    public List<Role> GetRoles() {
+    public List<Role> getRoles() {
         return roleRepository.findAll();
     }
 

--- a/src/main/java/com/ecore/roles/service/impl/RolesServiceImpl.java
+++ b/src/main/java/com/ecore/roles/service/impl/RolesServiceImpl.java
@@ -23,8 +23,6 @@ import lombok.extern.log4j.Log4j2;
 @Service
 public class RolesServiceImpl implements RolesService {
 
-    public static final String DEFAULT_ROLE = "Developer";
-
     private final RoleRepository roleRepository;
     private final MembershipRepository membershipRepository;
 
@@ -60,7 +58,7 @@ public class RolesServiceImpl implements RolesService {
         List<Membership> memberships = membershipRepository.findByUserIdAndTeamId(userId, teamId);
 
         if (memberships.isEmpty()) {
-            throw new ResourceNotFoundException(Role.class, null);
+            throw new ResourceNotFoundException(Role.class);
         }
 
         ArrayList<RoleDto> roles = new ArrayList<>();

--- a/src/main/java/com/ecore/roles/service/impl/TeamsServiceImpl.java
+++ b/src/main/java/com/ecore/roles/service/impl/TeamsServiceImpl.java
@@ -1,13 +1,17 @@
 package com.ecore.roles.service.impl;
 
-import com.ecore.roles.client.TeamsClient;
-import com.ecore.roles.client.model.Team;
-import com.ecore.roles.service.TeamsService;
+import java.util.List;
+import java.util.UUID;
+
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 
-import java.util.List;
-import java.util.UUID;
+import com.ecore.roles.client.TeamsClient;
+import com.ecore.roles.client.model.Team;
+import com.ecore.roles.exception.ResourceNotFoundException;
+import com.ecore.roles.service.TeamsService;
+
+import static java.util.Optional.ofNullable;
 
 @Service
 public class TeamsServiceImpl implements TeamsService {
@@ -25,5 +29,17 @@ public class TeamsServiceImpl implements TeamsService {
 
     public List<Team> getTeams() {
         return teamsClient.getTeams().getBody();
+    }
+
+    public boolean isMemberOfTeam(UUID teamId, UUID userId) {
+
+        Team team = ofNullable(getTeam(teamId))
+                .orElseThrow(() -> new ResourceNotFoundException(Team.class, teamId));
+
+        if (team.getTeamLeadId().equals(userId) || team.getTeamMemberIds().contains(userId)) {
+            return true;
+        }
+
+        return false;
     }
 }

--- a/src/main/java/com/ecore/roles/service/impl/TeamsServiceImpl.java
+++ b/src/main/java/com/ecore/roles/service/impl/TeamsServiceImpl.java
@@ -36,10 +36,6 @@ public class TeamsServiceImpl implements TeamsService {
         Team team = ofNullable(getTeam(teamId))
                 .orElseThrow(() -> new ResourceNotFoundException(Team.class, teamId));
 
-        if (team.getTeamLeadId().equals(userId) || team.getTeamMemberIds().contains(userId)) {
-            return true;
-        }
-
-        return false;
+        return (team.getTeamLeadId().equals(userId) || team.getTeamMemberIds().contains(userId));
     }
 }

--- a/src/main/java/com/ecore/roles/utils/MessageUtil.java
+++ b/src/main/java/com/ecore/roles/utils/MessageUtil.java
@@ -1,4 +1,4 @@
-package com.ecore.roles;
+package com.ecore.roles.utils;
 
 public class MessageUtil {
 

--- a/src/main/java/com/ecore/roles/web/RolesApi.java
+++ b/src/main/java/com/ecore/roles/web/RolesApi.java
@@ -1,10 +1,11 @@
 package com.ecore.roles.web;
 
-import com.ecore.roles.web.dto.RoleDto;
-import org.springframework.http.ResponseEntity;
-
 import java.util.List;
 import java.util.UUID;
+
+import org.springframework.http.ResponseEntity;
+
+import com.ecore.roles.web.dto.RoleDto;
 
 public interface RolesApi {
 
@@ -15,5 +16,9 @@ public interface RolesApi {
 
     ResponseEntity<RoleDto> getRole(
             UUID roleId);
+
+    ResponseEntity<List<RoleDto>> getRoles(
+            UUID teamMemberId,
+            UUID teamId);
 
 }

--- a/src/main/java/com/ecore/roles/web/rest/DefaultExceptionHandler.java
+++ b/src/main/java/com/ecore/roles/web/rest/DefaultExceptionHandler.java
@@ -1,35 +1,43 @@
 package com.ecore.roles.web.rest;
 
-import com.ecore.roles.exception.ErrorResponse;
-import com.ecore.roles.exception.ResourceExistsException;
-import com.ecore.roles.exception.ResourceNotFoundException;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.ControllerAdvice;
 import org.springframework.web.bind.annotation.ExceptionHandler;
+
+import com.ecore.roles.exception.ErrorResponse;
+import com.ecore.roles.exception.InvalidArgumentException;
+import com.ecore.roles.exception.ResourceExistsException;
+import com.ecore.roles.exception.ResourceNotFoundException;
 
 @ControllerAdvice
 public class DefaultExceptionHandler {
 
     @ExceptionHandler
     public ResponseEntity<ErrorResponse> handle(ResourceNotFoundException exception) {
-        return createResponse(404, exception.getMessage());
+        return createResponse(HttpStatus.NOT_FOUND, exception.getMessage());
     }
 
     @ExceptionHandler
     public ResponseEntity<ErrorResponse> handle(ResourceExistsException exception) {
-        return createResponse(400, exception.getMessage());
+        return createResponse(HttpStatus.BAD_REQUEST, exception.getMessage());
+    }
+
+    @ExceptionHandler
+    public ResponseEntity<ErrorResponse> handle(InvalidArgumentException exception) {
+        return createResponse(HttpStatus.BAD_REQUEST, exception.getMessage());
     }
 
     @ExceptionHandler
     public ResponseEntity<ErrorResponse> handle(IllegalStateException exception) {
-        return createResponse(500, exception.getMessage());
+        return createResponse(HttpStatus.INTERNAL_SERVER_ERROR, exception.getMessage());
     }
 
-    private ResponseEntity<ErrorResponse> createResponse(int status, String exception) {
+    private ResponseEntity<ErrorResponse> createResponse(HttpStatus httpStatus, String exception) {
         return ResponseEntity
-                .status(status)
+                .status(httpStatus)
                 .body(ErrorResponse.builder()
-                        .status(status)
+                        .status(httpStatus.value())
                         .error(exception).build());
     }
 }

--- a/src/main/java/com/ecore/roles/web/rest/MembershipsRestController.java
+++ b/src/main/java/com/ecore/roles/web/rest/MembershipsRestController.java
@@ -1,31 +1,39 @@
 package com.ecore.roles.web.rest;
 
-import com.ecore.roles.model.Membership;
-import com.ecore.roles.service.MembershipsService;
-import com.ecore.roles.web.MembershipsApi;
-import com.ecore.roles.web.dto.MembershipDto;
-import lombok.RequiredArgsConstructor;
-import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.*;
-import javax.validation.Valid;
-import javax.validation.constraints.NotNull;
+import static com.ecore.roles.web.dto.MembershipDto.fromModel;
+
 import java.util.ArrayList;
 import java.util.List;
 import java.util.UUID;
 
-import static com.ecore.roles.web.dto.MembershipDto.fromModel;
+import javax.validation.Valid;
+import javax.validation.constraints.NotNull;
+
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+import com.ecore.roles.model.Membership;
+import com.ecore.roles.service.MembershipsService;
+import com.ecore.roles.web.MembershipsApi;
+import com.ecore.roles.web.dto.MembershipDto;
+
+import lombok.RequiredArgsConstructor;
 
 @RequiredArgsConstructor
 @RestController
-@RequestMapping(value = "/v1/roles/memberships")
+@RequestMapping(value = "/v1/roles/memberships", produces = "application/json")
 public class MembershipsRestController implements MembershipsApi {
 
     private final MembershipsService membershipsService;
 
     @Override
     @PostMapping(
-            consumes = {"application/json"},
-            produces = {"application/json"})
+            consumes = {"application/json"})
     public ResponseEntity<MembershipDto> assignRoleToMembership(
             @NotNull @Valid @RequestBody MembershipDto membershipDto) {
         Membership membership = membershipsService.assignRoleToMembership(membershipDto.toModel());
@@ -35,9 +43,8 @@ public class MembershipsRestController implements MembershipsApi {
     }
 
     @Override
-    @PostMapping(
-            path = "/search",
-            produces = {"application/json"})
+    @GetMapping(
+            path = "/search")
     public ResponseEntity<List<MembershipDto>> getMemberships(
             @RequestParam UUID roleId) {
 

--- a/src/main/java/com/ecore/roles/web/rest/MembershipsRestController.java
+++ b/src/main/java/com/ecore/roles/web/rest/MembershipsRestController.java
@@ -9,6 +9,7 @@ import java.util.UUID;
 import javax.validation.Valid;
 import javax.validation.constraints.NotNull;
 
+import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -38,7 +39,7 @@ public class MembershipsRestController implements MembershipsApi {
             @NotNull @Valid @RequestBody MembershipDto membershipDto) {
         Membership membership = membershipsService.assignRoleToMembership(membershipDto.toModel());
         return ResponseEntity
-                .status(200)
+                .status(HttpStatus.CREATED)
                 .body(fromModel(membership));
     }
 
@@ -58,7 +59,7 @@ public class MembershipsRestController implements MembershipsApi {
         }
 
         return ResponseEntity
-                .status(200)
+                .status(HttpStatus.OK)
                 .body(newMembershipDto);
     }
 

--- a/src/main/java/com/ecore/roles/web/rest/RolesRestController.java
+++ b/src/main/java/com/ecore/roles/web/rest/RolesRestController.java
@@ -5,6 +5,8 @@ import com.ecore.roles.service.RolesService;
 import com.ecore.roles.web.RolesApi;
 import com.ecore.roles.web.dto.RoleDto;
 import lombok.RequiredArgsConstructor;
+
+import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
@@ -28,7 +30,7 @@ public class RolesRestController implements RolesApi {
     public ResponseEntity<RoleDto> createRole(
             @Valid @RequestBody RoleDto role) {
         return ResponseEntity
-                .status(200)
+                .status(HttpStatus.CREATED)
                 .body(fromModel(rolesService.createRole(role.toModel())));
     }
 
@@ -46,7 +48,7 @@ public class RolesRestController implements RolesApi {
         }
 
         return ResponseEntity
-                .status(200)
+                .status(HttpStatus.OK)
                 .body(roleDtoList);
     }
 
@@ -56,7 +58,7 @@ public class RolesRestController implements RolesApi {
     public ResponseEntity<RoleDto> getRole(
             @PathVariable UUID roleId) {
         return ResponseEntity
-                .status(200)
+                .status(HttpStatus.OK)
                 .body(fromModel(rolesService.getRole(roleId)));
     }
 

--- a/src/main/java/com/ecore/roles/web/rest/RolesRestController.java
+++ b/src/main/java/com/ecore/roles/web/rest/RolesRestController.java
@@ -62,4 +62,15 @@ public class RolesRestController implements RolesApi {
                 .body(fromModel(rolesService.getRole(roleId)));
     }
 
+    @Override
+    @GetMapping(
+            path = "/search")
+    public ResponseEntity<List<RoleDto>> getRoles(
+            @RequestParam UUID teamMemberId,
+            @RequestParam UUID teamId) {
+        return ResponseEntity
+                .status(HttpStatus.OK)
+                .body(rolesService.getRoles(teamMemberId, teamId));
+    }
+
 }

--- a/src/main/java/com/ecore/roles/web/rest/RolesRestController.java
+++ b/src/main/java/com/ecore/roles/web/rest/RolesRestController.java
@@ -30,7 +30,7 @@ public class RolesRestController implements RolesApi {
             @Valid @RequestBody RoleDto role) {
         return ResponseEntity
                 .status(200)
-                .body(fromModel(rolesService.CreateRole(role.toModel())));
+                .body(fromModel(rolesService.createRole(role.toModel())));
     }
 
     @Override
@@ -38,7 +38,7 @@ public class RolesRestController implements RolesApi {
             produces = {"application/json"})
     public ResponseEntity<List<RoleDto>> getRoles() {
 
-        List<Role> getRoles = rolesService.GetRoles();
+        List<Role> getRoles = rolesService.getRoles();
 
         List<RoleDto> roleDtoList = new ArrayList<>();
 
@@ -60,7 +60,7 @@ public class RolesRestController implements RolesApi {
             @PathVariable UUID roleId) {
         return ResponseEntity
                 .status(200)
-                .body(fromModel(rolesService.GetRole(roleId)));
+                .body(fromModel(rolesService.getRole(roleId)));
     }
 
 }

--- a/src/main/java/com/ecore/roles/web/rest/RolesRestController.java
+++ b/src/main/java/com/ecore/roles/web/rest/RolesRestController.java
@@ -17,15 +17,14 @@ import static com.ecore.roles.web.dto.RoleDto.fromModel;
 
 @RequiredArgsConstructor
 @RestController
-@RequestMapping(value = "/v1/roles")
+@RequestMapping(value = "/v1/roles", produces = {"application/json"})
 public class RolesRestController implements RolesApi {
 
     private final RolesService rolesService;
 
     @Override
     @PostMapping(
-            consumes = {"application/json"},
-            produces = {"application/json"})
+            consumes = {"application/json"})
     public ResponseEntity<RoleDto> createRole(
             @Valid @RequestBody RoleDto role) {
         return ResponseEntity
@@ -34,8 +33,7 @@ public class RolesRestController implements RolesApi {
     }
 
     @Override
-    @PostMapping(
-            produces = {"application/json"})
+    @GetMapping()
     public ResponseEntity<List<RoleDto>> getRoles() {
 
         List<Role> getRoles = rolesService.getRoles();
@@ -53,9 +51,8 @@ public class RolesRestController implements RolesApi {
     }
 
     @Override
-    @PostMapping(
-            path = "/{roleId}",
-            produces = {"application/json"})
+    @GetMapping(
+            path = "/{roleId}")
     public ResponseEntity<RoleDto> getRole(
             @PathVariable UUID roleId) {
         return ResponseEntity

--- a/src/main/java/com/ecore/roles/web/rest/TeamsRestController.java
+++ b/src/main/java/com/ecore/roles/web/rest/TeamsRestController.java
@@ -1,31 +1,32 @@
 package com.ecore.roles.web.rest;
 
-import com.ecore.roles.service.TeamsService;
-import com.ecore.roles.web.TeamsApi;
-import com.ecore.roles.web.dto.TeamDto;
-import lombok.RequiredArgsConstructor;
-import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import static com.ecore.roles.web.dto.TeamDto.fromModel;
 
 import java.util.List;
 import java.util.UUID;
 import java.util.stream.Collectors;
 
-import static com.ecore.roles.web.dto.TeamDto.fromModel;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import com.ecore.roles.service.TeamsService;
+import com.ecore.roles.web.TeamsApi;
+import com.ecore.roles.web.dto.TeamDto;
+
+import lombok.RequiredArgsConstructor;
 
 @RequiredArgsConstructor
 @RestController
-@RequestMapping(value = "/v1/teams")
+@RequestMapping(value = "/v1/teams", produces = {"application/json"})
 public class TeamsRestController implements TeamsApi {
 
     private final TeamsService teamsService;
 
     @Override
-    @PostMapping(
-            produces = {"application/json"})
+    @GetMapping()
     public ResponseEntity<List<TeamDto>> getTeams() {
         return ResponseEntity
                 .status(200)
@@ -35,9 +36,8 @@ public class TeamsRestController implements TeamsApi {
     }
 
     @Override
-    @PostMapping(
-            path = "/{teamId}",
-            produces = {"application/json"})
+    @GetMapping(
+            path = "/{teamId}")
     public ResponseEntity<TeamDto> getTeam(
             @PathVariable UUID teamId) {
         return ResponseEntity

--- a/src/main/java/com/ecore/roles/web/rest/UsersRestController.java
+++ b/src/main/java/com/ecore/roles/web/rest/UsersRestController.java
@@ -1,31 +1,32 @@
 package com.ecore.roles.web.rest;
 
-import com.ecore.roles.service.UsersService;
-import com.ecore.roles.web.UsersApi;
-import com.ecore.roles.web.dto.UserDto;
-import lombok.RequiredArgsConstructor;
-import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import static com.ecore.roles.web.dto.UserDto.fromModel;
 
 import java.util.List;
 import java.util.UUID;
 import java.util.stream.Collectors;
 
-import static com.ecore.roles.web.dto.UserDto.fromModel;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import com.ecore.roles.service.UsersService;
+import com.ecore.roles.web.UsersApi;
+import com.ecore.roles.web.dto.UserDto;
+
+import lombok.RequiredArgsConstructor;
 
 @RequiredArgsConstructor
 @RestController
-@RequestMapping(value = "/v1/users")
+@RequestMapping(value = "/v1/users", produces = {"application/json"})
 public class UsersRestController implements UsersApi {
 
     private final UsersService usersService;
 
     @Override
-    @PostMapping(
-            produces = {"application/json"})
+    @GetMapping()
     public ResponseEntity<List<UserDto>> getUsers() {
         return ResponseEntity
                 .status(200)
@@ -35,9 +36,8 @@ public class UsersRestController implements UsersApi {
     }
 
     @Override
-    @PostMapping(
-            path = "/{userId}",
-            produces = {"application/json"})
+    @GetMapping(
+            path = "/{userId}")
     public ResponseEntity<UserDto> getUser(
             @PathVariable UUID userId) {
         return ResponseEntity

--- a/src/test/java/com/ecore/roles/api/MembershipsApiTests.java
+++ b/src/test/java/com/ecore/roles/api/MembershipsApiTests.java
@@ -10,6 +10,7 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.web.server.LocalServerPort;
+import org.springframework.http.HttpStatus;
 import org.springframework.test.web.client.MockRestServiceServer;
 import org.springframework.web.client.RestTemplate;
 
@@ -25,6 +26,12 @@ public class MembershipsApiTests {
 
     private final MembershipRepository membershipRepository;
     private final RestTemplate restTemplate;
+    
+    private final int HTTP_BAD_REQUEST = HttpStatus.BAD_REQUEST.value();
+    private final int HTTP_NOT_FOUND = HttpStatus.NOT_FOUND.value();
+    private final int HTTP_CREATED = HttpStatus.CREATED.value();
+    private final int HTTP_OK = HttpStatus.OK.value();
+    
 
     private MockRestServiceServer mockServer;
 
@@ -57,7 +64,7 @@ public class MembershipsApiTests {
     @Test
     void shouldFailToCreateRoleMembershipWhenBodyIsNull() {
         createMembership(null)
-                .validate(400, "Bad Request");
+                .validate(HTTP_BAD_REQUEST, "Bad Request");
     }
 
     @Test
@@ -66,7 +73,7 @@ public class MembershipsApiTests {
         expectedMembership.setRole(null);
 
         createMembership(expectedMembership)
-                .validate(400, "Bad Request");
+                .validate(HTTP_BAD_REQUEST, "Bad Request");
     }
 
     @Test
@@ -75,7 +82,7 @@ public class MembershipsApiTests {
         expectedMembership.setRole(Role.builder().build());
 
         createMembership(expectedMembership)
-                .validate(400, "Bad Request");
+                .validate(HTTP_BAD_REQUEST, "Bad Request");
     }
 
     @Test
@@ -84,7 +91,7 @@ public class MembershipsApiTests {
         expectedMembership.setUserId(null);
 
         createMembership(expectedMembership)
-                .validate(400, "Bad Request");
+                .validate(HTTP_BAD_REQUEST, "Bad Request");
     }
 
     @Test
@@ -93,7 +100,7 @@ public class MembershipsApiTests {
         expectedMembership.setTeamId(null);
 
         createMembership(expectedMembership)
-                .validate(400, "Bad Request");
+                .validate(HTTP_BAD_REQUEST, "Bad Request");
     }
 
     @Test
@@ -101,7 +108,7 @@ public class MembershipsApiTests {
         createDefaultMembership();
 
         createMembership(DEFAULT_MEMBERSHIP())
-                .validate(400, "Membership already exists");
+                .validate(HTTP_BAD_REQUEST, "Membership already exists");
     }
 
     @Test
@@ -110,7 +117,7 @@ public class MembershipsApiTests {
         expectedMembership.setRole(Role.builder().id(UUID_1).build());
 
         createMembership(expectedMembership)
-                .validate(404, format("Role %s not found", UUID_1));
+                .validate(HTTP_NOT_FOUND, format("Role %s not found", UUID_1));
     }
 
     @Test
@@ -119,7 +126,7 @@ public class MembershipsApiTests {
         mockGetTeamById(mockServer, expectedMembership.getTeamId(), null);
 
         createMembership(expectedMembership)
-                .validate(404, format("Team %s not found", expectedMembership.getTeamId()));
+                .validate(HTTP_NOT_FOUND, format("Team %s not found", expectedMembership.getTeamId()));
     }
 
     @Test
@@ -128,7 +135,7 @@ public class MembershipsApiTests {
         mockGetTeamById(mockServer, expectedMembership.getTeamId(), ORDINARY_CORAL_LYNX_TEAM());
 
         createMembership(expectedMembership)
-                .validate(400,
+                .validate(HTTP_BAD_REQUEST,
                         "Invalid 'Membership' object. The provided user doesn't belong to the provided team.");
     }
 
@@ -138,7 +145,7 @@ public class MembershipsApiTests {
         Membership expectedMembership = DEFAULT_MEMBERSHIP();
 
         MembershipDto[] actualMemberships = getMemberships(expectedMembership.getRole().getId())
-                .statusCode(200)
+                .statusCode(HTTP_OK)
                 .extract().as(MembershipDto[].class);
 
         assertThat(actualMemberships.length).isEqualTo(1);
@@ -149,7 +156,7 @@ public class MembershipsApiTests {
     @Test
     void shouldGetAllMembershipsButReturnsEmptyList() {
         MembershipDto[] actualMemberships = getMemberships(DEVELOPER_ROLE_UUID)
-                .statusCode(200)
+                .statusCode(HTTP_OK)
                 .extract().as(MembershipDto[].class);
 
         assertThat(actualMemberships.length).isEqualTo(0);
@@ -158,7 +165,7 @@ public class MembershipsApiTests {
     @Test
     void shouldFailToGetAllMembershipsWhenRoleIdIsNull() {
         getMemberships(null)
-                .validate(400, "Bad Request");
+                .validate(HTTP_BAD_REQUEST, "Bad Request");
     }
 
     private MembershipDto createDefaultMembership() {
@@ -166,7 +173,7 @@ public class MembershipsApiTests {
         mockGetTeamById(mockServer, expectedMembership.getTeamId(), ORDINARY_CORAL_LYNX_TEAM());
 
         return createMembership(expectedMembership)
-                .statusCode(201)
+                .statusCode(HTTP_CREATED)
                 .extract().as(MembershipDto.class);
     }
 

--- a/src/test/java/com/ecore/roles/api/MembershipsApiTests.java
+++ b/src/test/java/com/ecore/roles/api/MembershipsApiTests.java
@@ -33,7 +33,7 @@ import static com.ecore.roles.MessageUtil.PROV_USR_DOESNT_BELONG_PROV_TEAM;
 import static com.ecore.roles.MessageUtil.BAD_REQUEST;
 
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
-public class MembershipsApiTests {
+class MembershipsApiTests {
 
     private final MembershipRepository membershipRepository;
     private final RestTemplate restTemplate;
@@ -160,7 +160,7 @@ public class MembershipsApiTests {
                 .statusCode(RestAssuredHelper.HTTP_OK)
                 .extract().as(MembershipDto[].class);
 
-        assertThat(actualMemberships.length).isEqualTo(1);
+        assertThat(actualMemberships).hasSize(1);
         assertThat(actualMemberships[0].getId()).isNotNull();
         assertThat(actualMemberships[0]).isEqualTo(MembershipDto.fromModel(expectedMembership));
     }
@@ -171,7 +171,7 @@ public class MembershipsApiTests {
                 .statusCode(RestAssuredHelper.HTTP_OK)
                 .extract().as(MembershipDto[].class);
 
-        assertThat(actualMemberships.length).isEqualTo(0);
+        assertThat(actualMemberships).isEmpty();
     }
 
     @Test

--- a/src/test/java/com/ecore/roles/api/MembershipsApiTests.java
+++ b/src/test/java/com/ecore/roles/api/MembershipsApiTests.java
@@ -1,5 +1,10 @@
 package com.ecore.roles.api;
 
+import static com.ecore.roles.utils.MessageUtil.BAD_REQUEST;
+import static com.ecore.roles.utils.MessageUtil.INVALID_S_OBJECT;
+import static com.ecore.roles.utils.MessageUtil.PROV_USR_DOESNT_BELONG_PROV_TEAM;
+import static com.ecore.roles.utils.MessageUtil.S_ALREADY_EXISTS;
+import static com.ecore.roles.utils.MessageUtil.S_S_NOT_FOUND;
 import static com.ecore.roles.utils.MockUtils.mockGetTeamById;
 import static com.ecore.roles.utils.RestAssuredHelper.createMembership;
 import static com.ecore.roles.utils.RestAssuredHelper.getMemberships;
@@ -25,12 +30,6 @@ import com.ecore.roles.model.Role;
 import com.ecore.roles.repository.MembershipRepository;
 import com.ecore.roles.utils.RestAssuredHelper;
 import com.ecore.roles.web.dto.MembershipDto;
-
-import static com.ecore.roles.MessageUtil.S_ALREADY_EXISTS;
-import static com.ecore.roles.MessageUtil.S_S_NOT_FOUND;
-import static com.ecore.roles.MessageUtil.INVALID_S_OBJECT;
-import static com.ecore.roles.MessageUtil.PROV_USR_DOESNT_BELONG_PROV_TEAM;
-import static com.ecore.roles.MessageUtil.BAD_REQUEST;
 
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
 class MembershipsApiTests {

--- a/src/test/java/com/ecore/roles/api/RolesApiTest.java
+++ b/src/test/java/com/ecore/roles/api/RolesApiTest.java
@@ -23,6 +23,7 @@ import static com.ecore.roles.utils.RestAssuredHelper.getRole;
 import static com.ecore.roles.utils.RestAssuredHelper.getRoles;
 import static com.ecore.roles.utils.RestAssuredHelper.sendRequest;
 import static com.ecore.roles.utils.TestData.DEFAULT_MEMBERSHIP;
+import static com.ecore.roles.utils.TestData.GIANNI_TESTER_MEMBERSHIP;
 import static com.ecore.roles.utils.TestData.DEVELOPER_ROLE;
 import static com.ecore.roles.utils.TestData.DEVOPS_ROLE;
 import static com.ecore.roles.utils.TestData.GIANNI_USER_UUID;
@@ -141,6 +142,29 @@ public class RolesApiTest {
         expectedApiResult.add(expectedMembership.getRole().getName());
 
         getRole(expectedMembership.getUserId(), expectedMembership.getTeamId())
+                .statusCode(RestAssuredHelper.HTTP_OK)
+                .body("name", equalTo(expectedApiResult));
+    }
+
+    @Test
+    void shouldGetMoreThanOneRoleByUserIdAndTeamId() {
+        Membership expectedMembershipGianniTester = GIANNI_TESTER_MEMBERSHIP();
+
+        mockGetTeamById(mockServer, ORDINARY_CORAL_LYNX_TEAM_UUID, ORDINARY_CORAL_LYNX_TEAM());
+
+        createMembership(expectedMembershipGianniTester)
+                .statusCode(RestAssuredHelper.HTTP_CREATED);
+
+        ArrayList<String> expectedApiResult = new ArrayList<>();
+
+        /*
+         * Developer role should be inserted by previous test shouldGetRoleByUserIdAndTeamId
+         */
+        expectedApiResult.add(DEVELOPER_ROLE().getName());
+
+        expectedApiResult.add(expectedMembershipGianniTester.getRole().getName());
+
+        getRole(expectedMembershipGianniTester.getUserId(), expectedMembershipGianniTester.getTeamId())
                 .statusCode(RestAssuredHelper.HTTP_OK)
                 .body("name", equalTo(expectedApiResult));
     }

--- a/src/test/java/com/ecore/roles/api/RolesApiTest.java
+++ b/src/test/java/com/ecore/roles/api/RolesApiTest.java
@@ -13,6 +13,7 @@ import org.springframework.boot.web.server.LocalServerPort;
 import org.springframework.test.web.client.MockRestServiceServer;
 import org.springframework.web.client.RestTemplate;
 
+import java.util.ArrayList;
 import java.util.Optional;
 
 import static com.ecore.roles.utils.MockUtils.mockGetTeamById;
@@ -136,9 +137,12 @@ public class RolesApiTest {
         createMembership(expectedMembership)
                 .statusCode(RestAssuredHelper.HTTP_CREATED);
 
+        ArrayList<String> expectedApiResult = new ArrayList<>();
+        expectedApiResult.add(expectedMembership.getRole().getName());
+
         getRole(expectedMembership.getUserId(), expectedMembership.getTeamId())
                 .statusCode(RestAssuredHelper.HTTP_OK)
-                .body("name", equalTo(expectedMembership.getRole().getName()));
+                .body("name", equalTo(expectedApiResult));
     }
 
     @Test
@@ -157,6 +161,6 @@ public class RolesApiTest {
     void shouldFailToGetRoleByUserIdAndTeamIdWhenItDoesNotExist() {
         mockGetTeamById(mockServer, UUID_1, null);
         getRole(GIANNI_USER_UUID, UUID_1)
-                .validate(RestAssuredHelper.HTTP_NOT_FOUND, format("Team %s not found", UUID_1));
+                .validate(RestAssuredHelper.HTTP_NOT_FOUND, "Role null not found");
     }
 }

--- a/src/test/java/com/ecore/roles/api/RolesApiTest.java
+++ b/src/test/java/com/ecore/roles/api/RolesApiTest.java
@@ -65,7 +65,7 @@ public class RolesApiTest {
         sendRequest(when()
                 .get("/v1/role")
                 .then())
-                        .validate(404, "Not Found");
+                        .validate(RestAssuredHelper.HTTP_NOT_FOUND, "Not Found");
     }
 
     @Test
@@ -73,7 +73,7 @@ public class RolesApiTest {
         Role expectedRole = DEVOPS_ROLE();
 
         RoleDto actualRole = createRole(expectedRole)
-                .statusCode(201)
+                .statusCode(RestAssuredHelper.HTTP_CREATED)
                 .extract().as(RoleDto.class);
 
         assertThat(actualRole.getName()).isEqualTo(expectedRole.getName());
@@ -82,25 +82,25 @@ public class RolesApiTest {
     @Test
     void shouldFailToCreateNewRoleWhenNull() {
         createRole(null)
-                .validate(400, "Bad Request");
+                .validate(RestAssuredHelper.HTTP_BAD_REQUEST, "Bad Request");
     }
 
     @Test
     void shouldFailToCreateNewRoleWhenMissingName() {
         createRole(Role.builder().build())
-                .validate(400, "Bad Request");
+                .validate(RestAssuredHelper.HTTP_BAD_REQUEST, "Bad Request");
     }
 
     @Test
     void shouldFailToCreateNewRoleWhenBlankName() {
         createRole(Role.builder().name("").build())
-                .validate(400, "Bad Request");
+                .validate(RestAssuredHelper.HTTP_BAD_REQUEST, "Bad Request");
     }
 
     @Test
     void shouldFailToCreateNewRoleWhenNameAlreadyExists() {
         createRole(DEVELOPER_ROLE())
-                .validate(400, "Role already exists");
+                .validate(RestAssuredHelper.HTTP_BAD_REQUEST, "Role already exists");
     }
 
     @Test
@@ -119,14 +119,14 @@ public class RolesApiTest {
         Role expectedRole = DEVELOPER_ROLE();
 
         getRole(expectedRole.getId())
-                .statusCode(200)
+                .statusCode(RestAssuredHelper.HTTP_OK)
                 .body("name", equalTo(expectedRole.getName()));
     }
 
     @Test
     void shouldFailToGetRoleById() {
         getRole(UUID_1)
-                .validate(404, format("Role %s not found", UUID_1));
+                .validate(RestAssuredHelper.HTTP_NOT_FOUND, format("Role %s not found", UUID_1));
     }
 
     @Test
@@ -134,29 +134,29 @@ public class RolesApiTest {
         Membership expectedMembership = DEFAULT_MEMBERSHIP();
         mockGetTeamById(mockServer, ORDINARY_CORAL_LYNX_TEAM_UUID, ORDINARY_CORAL_LYNX_TEAM());
         createMembership(expectedMembership)
-                .statusCode(201);
+                .statusCode(RestAssuredHelper.HTTP_CREATED);
 
         getRole(expectedMembership.getUserId(), expectedMembership.getTeamId())
-                .statusCode(200)
+                .statusCode(RestAssuredHelper.HTTP_OK)
                 .body("name", equalTo(expectedMembership.getRole().getName()));
     }
 
     @Test
     void shouldFailToGetRoleByUserIdAndTeamIdWhenMissingUserId() {
         getRole(null, ORDINARY_CORAL_LYNX_TEAM_UUID)
-                .validate(400, "Bad Request");
+                .validate(RestAssuredHelper.HTTP_BAD_REQUEST, "Bad Request");
     }
 
     @Test
     void shouldFailToGetRoleByUserIdAndTeamIdWhenMissingTeamId() {
         getRole(GIANNI_USER_UUID, null)
-                .validate(400, "Bad Request");
+                .validate(RestAssuredHelper.HTTP_BAD_REQUEST, "Bad Request");
     }
 
     @Test
     void shouldFailToGetRoleByUserIdAndTeamIdWhenItDoesNotExist() {
         mockGetTeamById(mockServer, UUID_1, null);
         getRole(GIANNI_USER_UUID, UUID_1)
-                .validate(404, format("Team %s not found", UUID_1));
+                .validate(RestAssuredHelper.HTTP_NOT_FOUND, format("Team %s not found", UUID_1));
     }
 }

--- a/src/test/java/com/ecore/roles/api/RolesApiTest.java
+++ b/src/test/java/com/ecore/roles/api/RolesApiTest.java
@@ -45,7 +45,7 @@ import static com.ecore.roles.MessageUtil.BAD_REQUEST;
 import static com.ecore.roles.MessageUtil.NOT_FOUND;;
 
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
-public class RolesApiTest {
+class RolesApiTest {
 
     private final RestTemplate restTemplate;
     private final RoleRepository roleRepository;
@@ -121,10 +121,11 @@ public class RolesApiTest {
         RoleDto[] roles = getRoles()
                 .extract().as(RoleDto[].class);
 
-        assertThat(roles.length).isGreaterThanOrEqualTo(3);
-        assertThat(roles).contains(RoleDto.fromModel(DEVELOPER_ROLE()));
-        assertThat(roles).contains(RoleDto.fromModel(PRODUCT_OWNER_ROLE()));
-        assertThat(roles).contains(RoleDto.fromModel(TESTER_ROLE()));
+        assertThat(roles)
+                .hasSizeGreaterThanOrEqualTo(3)
+                .contains(RoleDto.fromModel(DEVELOPER_ROLE()))
+                .contains(RoleDto.fromModel(PRODUCT_OWNER_ROLE()))
+                .contains(RoleDto.fromModel(TESTER_ROLE()));
     }
 
     @Test

--- a/src/test/java/com/ecore/roles/api/RolesApiTest.java
+++ b/src/test/java/com/ecore/roles/api/RolesApiTest.java
@@ -17,6 +17,11 @@ import org.springframework.web.client.RestTemplate;
 import java.util.ArrayList;
 import java.util.Optional;
 
+import static com.ecore.roles.utils.MessageUtil.BAD_REQUEST;
+import static com.ecore.roles.utils.MessageUtil.NOT_FOUND;
+import static com.ecore.roles.utils.MessageUtil.S_ALREADY_EXISTS;
+import static com.ecore.roles.utils.MessageUtil.S_NOT_FOUND;
+import static com.ecore.roles.utils.MessageUtil.S_S_NOT_FOUND;
 import static com.ecore.roles.utils.MockUtils.mockGetTeamById;
 import static com.ecore.roles.utils.RestAssuredHelper.createMembership;
 import static com.ecore.roles.utils.RestAssuredHelper.createRole;
@@ -36,13 +41,7 @@ import static com.ecore.roles.utils.TestData.UUID_1;
 import static io.restassured.RestAssured.when;
 import static java.lang.String.format;
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.hamcrest.Matchers.equalTo;
-
-import static com.ecore.roles.MessageUtil.S_ALREADY_EXISTS;
-import static com.ecore.roles.MessageUtil.S_S_NOT_FOUND;
-import static com.ecore.roles.MessageUtil.S_NOT_FOUND;
-import static com.ecore.roles.MessageUtil.BAD_REQUEST;
-import static com.ecore.roles.MessageUtil.NOT_FOUND;;
+import static org.hamcrest.Matchers.equalTo;;
 
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
 class RolesApiTest {

--- a/src/test/java/com/ecore/roles/service/MembershipsServiceTest.java
+++ b/src/test/java/com/ecore/roles/service/MembershipsServiceTest.java
@@ -1,7 +1,7 @@
 package com.ecore.roles.service;
 
-import static com.ecore.roles.MessageUtil.S_ALREADY_EXISTS;
-import static com.ecore.roles.MessageUtil.INVALID_S_OBJECT;
+import static com.ecore.roles.utils.MessageUtil.INVALID_S_OBJECT;
+import static com.ecore.roles.utils.MessageUtil.S_ALREADY_EXISTS;
 import static com.ecore.roles.utils.TestData.DEFAULT_MEMBERSHIP;
 import static com.ecore.roles.utils.TestData.DEVELOPER_ROLE;
 import static java.lang.String.format;

--- a/src/test/java/com/ecore/roles/service/MembershipsServiceTest.java
+++ b/src/test/java/com/ecore/roles/service/MembershipsServiceTest.java
@@ -42,22 +42,23 @@ class MembershipsServiceTest {
 
     @Test
     public void shouldCreateMembership() {
-        Membership nemMembershipToCreate = TestData.NEW_MEMBERSHIP(false);
+        Membership newMembershipToCreate = TestData.NEW_MEMBERSHIP(false);
         Membership expectedMembership = TestData.NEW_MEMBERSHIP(true);
 
-        when(roleRepository.findById(nemMembershipToCreate.getRole().getId()))
+        when(roleRepository.findById(newMembershipToCreate.getRole().getId()))
                 .thenReturn(Optional.ofNullable(DEVELOPER_ROLE()));
-        when(membershipRepository.findByUserIdAndTeamId(nemMembershipToCreate.getUserId(),
-                nemMembershipToCreate.getTeamId()))
+        when(membershipRepository.findByRoleIdAndUserIdAndTeamId(newMembershipToCreate.getRole().getId(),
+                newMembershipToCreate.getUserId(),
+                newMembershipToCreate.getTeamId()))
                         .thenReturn(Optional.empty());
         when(membershipRepository
-                .save(nemMembershipToCreate))
+                .save(newMembershipToCreate))
                         .thenReturn(expectedMembership);
-        when(teamsService.isMemberOfTeam(nemMembershipToCreate.getTeamId(),
-                nemMembershipToCreate.getUserId()))
+        when(teamsService.isMemberOfTeam(newMembershipToCreate.getTeamId(),
+                newMembershipToCreate.getUserId()))
                         .thenReturn(true);
 
-        Membership actualMembership = membershipsService.assignRoleToMembership(nemMembershipToCreate);
+        Membership actualMembership = membershipsService.assignRoleToMembership(newMembershipToCreate);
 
         assertNotNull(actualMembership);
         assertEquals(actualMembership, expectedMembership);
@@ -73,7 +74,8 @@ class MembershipsServiceTest {
     @Test
     public void shouldFailToCreateMembershipWhenItExists() {
         Membership expectedMembership = DEFAULT_MEMBERSHIP();
-        when(membershipRepository.findByUserIdAndTeamId(expectedMembership.getUserId(),
+        when(membershipRepository.findByRoleIdAndUserIdAndTeamId(expectedMembership.getRole().getId(),
+                expectedMembership.getUserId(),
                 expectedMembership.getTeamId()))
                         .thenReturn(Optional.of(expectedMembership));
 

--- a/src/test/java/com/ecore/roles/service/MembershipsServiceTest.java
+++ b/src/test/java/com/ecore/roles/service/MembershipsServiceTest.java
@@ -1,12 +1,19 @@
 package com.ecore.roles.service;
 
-import com.ecore.roles.exception.InvalidArgumentException;
-import com.ecore.roles.exception.ResourceExistsException;
-import com.ecore.roles.model.Membership;
-import com.ecore.roles.repository.MembershipRepository;
-import com.ecore.roles.repository.RoleRepository;
-import com.ecore.roles.service.impl.MembershipsServiceImpl;
-import com.ecore.roles.utils.TestData;
+import static com.ecore.roles.MessageUtil.S_ALREADY_EXISTS;
+import static com.ecore.roles.MessageUtil.INVALID_S_OBJECT;
+import static com.ecore.roles.utils.TestData.DEFAULT_MEMBERSHIP;
+import static com.ecore.roles.utils.TestData.DEVELOPER_ROLE;
+import static java.lang.String.format;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.util.Optional;
 
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -14,17 +21,14 @@ import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
-import java.util.Optional;
-
-import static com.ecore.roles.utils.TestData.DEFAULT_MEMBERSHIP;
-import static com.ecore.roles.utils.TestData.DEVELOPER_ROLE;
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
-import static org.junit.jupiter.api.Assertions.assertThrows;
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.Mockito.times;
-import static org.mockito.Mockito.when;
-import static org.mockito.Mockito.verify;
+import com.ecore.roles.exception.InvalidArgumentException;
+import com.ecore.roles.exception.ResourceExistsException;
+import com.ecore.roles.model.Membership;
+import com.ecore.roles.model.Role;
+import com.ecore.roles.repository.MembershipRepository;
+import com.ecore.roles.repository.RoleRepository;
+import com.ecore.roles.service.impl.MembershipsServiceImpl;
+import com.ecore.roles.utils.TestData;
 
 @ExtendWith(MockitoExtension.class)
 class MembershipsServiceTest {
@@ -83,7 +87,7 @@ class MembershipsServiceTest {
         ResourceExistsException exception = assertThrows(ResourceExistsException.class,
                 () -> membershipsService.assignRoleToMembership(expectedMembership));
 
-        assertEquals("Membership already exists", exception.getMessage());
+        assertEquals(format(S_ALREADY_EXISTS, Membership.class.getSimpleName()), exception.getMessage());
         verify(roleRepository, times(0)).getById(any());
         verify(usersService, times(0)).getUser(any());
         verify(teamsService, times(0)).getTeam(any());
@@ -97,7 +101,7 @@ class MembershipsServiceTest {
         InvalidArgumentException exception = assertThrows(InvalidArgumentException.class,
                 () -> membershipsService.assignRoleToMembership(expectedMembership));
 
-        assertEquals("Invalid 'Role' object", exception.getMessage());
+        assertEquals(format(INVALID_S_OBJECT, Role.class.getSimpleName()), exception.getMessage());
         verify(membershipRepository, times(0)).findByUserIdAndTeamId(any(), any());
         verify(roleRepository, times(0)).getById(any());
         verify(usersService, times(0)).getUser(any());

--- a/src/test/java/com/ecore/roles/service/MembershipsServiceTest.java
+++ b/src/test/java/com/ecore/roles/service/MembershipsServiceTest.java
@@ -45,7 +45,7 @@ class MembershipsServiceTest {
     private TeamsService teamsService;
 
     @Test
-    public void shouldCreateMembership() {
+    void shouldCreateMembership() {
         Membership newMembershipToCreate = TestData.NEW_MEMBERSHIP(false);
         Membership expectedMembership = TestData.NEW_MEMBERSHIP(true);
 
@@ -70,13 +70,13 @@ class MembershipsServiceTest {
     }
 
     @Test
-    public void shouldFailToCreateMembershipWhenMembershipsIsNull() {
+    void shouldFailToCreateMembershipWhenMembershipsIsNull() {
         assertThrows(NullPointerException.class,
                 () -> membershipsService.assignRoleToMembership(null));
     }
 
     @Test
-    public void shouldFailToCreateMembershipWhenItExists() {
+    void shouldFailToCreateMembershipWhenItExists() {
         Membership expectedMembership = DEFAULT_MEMBERSHIP();
         when(membershipRepository.findByRoleIdAndUserIdAndTeamId(
                 expectedMembership.getRole().getId(),
@@ -94,7 +94,7 @@ class MembershipsServiceTest {
     }
 
     @Test
-    public void shouldFailToCreateMembershipWhenItHasInvalidRole() {
+    void shouldFailToCreateMembershipWhenItHasInvalidRole() {
         Membership expectedMembership = DEFAULT_MEMBERSHIP();
         expectedMembership.setRole(null);
 
@@ -109,7 +109,7 @@ class MembershipsServiceTest {
     }
 
     @Test
-    public void shouldFailToGetMembershipsWhenRoleIdIsNull() {
+    void shouldFailToGetMembershipsWhenRoleIdIsNull() {
         assertThrows(NullPointerException.class,
                 () -> membershipsService.getMemberships(null));
     }

--- a/src/test/java/com/ecore/roles/service/MembershipsServiceTest.java
+++ b/src/test/java/com/ecore/roles/service/MembershipsServiceTest.java
@@ -6,6 +6,8 @@ import com.ecore.roles.model.Membership;
 import com.ecore.roles.repository.MembershipRepository;
 import com.ecore.roles.repository.RoleRepository;
 import com.ecore.roles.service.impl.MembershipsServiceImpl;
+import com.ecore.roles.utils.TestData;
+
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
@@ -40,17 +42,22 @@ class MembershipsServiceTest {
 
     @Test
     public void shouldCreateMembership() {
-        Membership expectedMembership = DEFAULT_MEMBERSHIP();
-        when(roleRepository.findById(expectedMembership.getRole().getId()))
+        Membership nemMembershipToCreate = TestData.NEW_MEMBERSHIP(false);
+        Membership expectedMembership = TestData.NEW_MEMBERSHIP(true);
+
+        when(roleRepository.findById(nemMembershipToCreate.getRole().getId()))
                 .thenReturn(Optional.ofNullable(DEVELOPER_ROLE()));
-        when(membershipRepository.findByUserIdAndTeamId(expectedMembership.getUserId(),
-                expectedMembership.getTeamId()))
+        when(membershipRepository.findByUserIdAndTeamId(nemMembershipToCreate.getUserId(),
+                nemMembershipToCreate.getTeamId()))
                         .thenReturn(Optional.empty());
         when(membershipRepository
-                .save(expectedMembership))
+                .save(nemMembershipToCreate))
                         .thenReturn(expectedMembership);
+        when(teamsService.isMemberOfTeam(nemMembershipToCreate.getTeamId(),
+                nemMembershipToCreate.getUserId()))
+                        .thenReturn(true);
 
-        Membership actualMembership = membershipsService.assignRoleToMembership(expectedMembership);
+        Membership actualMembership = membershipsService.assignRoleToMembership(nemMembershipToCreate);
 
         assertNotNull(actualMembership);
         assertEquals(actualMembership, expectedMembership);

--- a/src/test/java/com/ecore/roles/service/MembershipsServiceTest.java
+++ b/src/test/java/com/ecore/roles/service/MembershipsServiceTest.java
@@ -74,7 +74,8 @@ class MembershipsServiceTest {
     @Test
     public void shouldFailToCreateMembershipWhenItExists() {
         Membership expectedMembership = DEFAULT_MEMBERSHIP();
-        when(membershipRepository.findByRoleIdAndUserIdAndTeamId(expectedMembership.getRole().getId(),
+        when(membershipRepository.findByRoleIdAndUserIdAndTeamId(
+                expectedMembership.getRole().getId(),
                 expectedMembership.getUserId(),
                 expectedMembership.getTeamId()))
                         .thenReturn(Optional.of(expectedMembership));

--- a/src/test/java/com/ecore/roles/service/RolesServiceTest.java
+++ b/src/test/java/com/ecore/roles/service/RolesServiceTest.java
@@ -41,7 +41,7 @@ class RolesServiceTest {
         Role developerRole = DEVELOPER_ROLE();
         when(roleRepository.save(developerRole)).thenReturn(developerRole);
 
-        Role role = rolesService.CreateRole(developerRole);
+        Role role = rolesService.createRole(developerRole);
 
         assertNotNull(role);
         assertEquals(developerRole, role);
@@ -50,7 +50,7 @@ class RolesServiceTest {
     @Test
     public void shouldFailToCreateRoleWhenRoleIsNull() {
         assertThrows(NullPointerException.class,
-                () -> rolesService.CreateRole(null));
+                () -> rolesService.createRole(null));
     }
 
     @Test
@@ -58,7 +58,7 @@ class RolesServiceTest {
         Role developerRole = DEVELOPER_ROLE();
         when(roleRepository.findById(developerRole.getId())).thenReturn(Optional.of(developerRole));
 
-        Role role = rolesService.GetRole(developerRole.getId());
+        Role role = rolesService.getRole(developerRole.getId());
 
         assertNotNull(role);
         assertEquals(developerRole, role);
@@ -67,7 +67,7 @@ class RolesServiceTest {
     @Test
     public void shouldFailToGetRoleWhenRoleIdDoesNotExist() {
         ResourceNotFoundException exception = assertThrows(ResourceNotFoundException.class,
-                () -> rolesService.GetRole(UUID_1));
+                () -> rolesService.getRole(UUID_1));
 
         assertEquals(format("Role %s not found", UUID_1), exception.getMessage());
     }

--- a/src/test/java/com/ecore/roles/service/RolesServiceTest.java
+++ b/src/test/java/com/ecore/roles/service/RolesServiceTest.java
@@ -26,6 +26,7 @@ import static com.ecore.roles.utils.TestData.UUID_1;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.when;
 
 @ExtendWith(MockitoExtension.class)
@@ -55,13 +56,13 @@ class RolesServiceTest {
     }
 
     @Test
-    public void shouldFailToCreateRoleWhenRoleIsNull() {
+    void shouldFailToCreateRoleWhenRoleIsNull() {
         assertThrows(NullPointerException.class,
                 () -> rolesService.createRole(null));
     }
 
     @Test
-    public void shouldReturnRoleWhenRoleIdExists() {
+    void shouldReturnRoleWhenRoleIdExists() {
         Role developerRole = DEVELOPER_ROLE();
         when(roleRepository.findById(developerRole.getId())).thenReturn(Optional.of(developerRole));
 
@@ -72,7 +73,7 @@ class RolesServiceTest {
     }
 
     @Test
-    public void shouldFailToGetRoleWhenRoleIdDoesNotExist() {
+    void shouldFailToGetRoleWhenRoleIdDoesNotExist() {
         ResourceNotFoundException exception = assertThrows(ResourceNotFoundException.class,
                 () -> rolesService.getRole(UUID_1));
 
@@ -80,7 +81,7 @@ class RolesServiceTest {
     }
 
     @Test
-    public void shouldGetRoleByUserIdAndTeamIdWhenExists() {
+    void shouldGetRoleByUserIdAndTeamIdWhenExists() {
         Membership gianniDeveloper = TestData.DEFAULT_MEMBERSHIP();
         List<Membership> memberships = new ArrayList<Membership>();
         memberships.add(gianniDeveloper);
@@ -100,7 +101,7 @@ class RolesServiceTest {
     }
 
     @Test
-    public void shouldGetMoreThanOneRoleByUserIdAndTeamIdWhenExists() {
+    void shouldGetMoreThanOneRoleByUserIdAndTeamIdWhenExists() {
         Membership gianniDeveloper = TestData.DEFAULT_MEMBERSHIP();
         Membership gianniTester = TestData.GIANNI_TESTER_MEMBERSHIP();
         List<Membership> memberships = new ArrayList<Membership>();
@@ -118,13 +119,13 @@ class RolesServiceTest {
                         gianniDeveloper.getTeamId());
 
         assertNotNull(returnedRoles);
-        assertEquals(returnedRoles.size(), 2);
+        assertThat(returnedRoles).hasSize(2);
         assertEquals(returnedRoles.get(0).getName(), gianniDeveloper.getRole().getName());
         assertEquals(returnedRoles.get(1).getName(), gianniTester.getRole().getName());
     }
 
     @Test
-    public void shouldThrowExceptionWhenUserDoesNotHaveRoleInATeam() {
+    void shouldThrowExceptionWhenUserDoesNotHaveRoleInATeam() {
         List<Membership> memberships = new ArrayList<Membership>();
 
         when(membershipRepository.findByUserIdAndTeamId(

--- a/src/test/java/com/ecore/roles/service/RolesServiceTest.java
+++ b/src/test/java/com/ecore/roles/service/RolesServiceTest.java
@@ -26,6 +26,7 @@ import static com.ecore.roles.utils.TestData.UUID_1;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.when;
 
 @ExtendWith(MockitoExtension.class)
@@ -44,7 +45,7 @@ class RolesServiceTest {
     private MembershipsService membershipsService;
 
     @Test
-    public void shouldCreateRole() {
+    void shouldCreateRole() {
         Role developerRole = DEVELOPER_ROLE();
         when(roleRepository.save(developerRole)).thenReturn(developerRole);
 
@@ -55,13 +56,13 @@ class RolesServiceTest {
     }
 
     @Test
-    public void shouldFailToCreateRoleWhenRoleIsNull() {
+    void shouldFailToCreateRoleWhenRoleIsNull() {
         assertThrows(NullPointerException.class,
                 () -> rolesService.createRole(null));
     }
 
     @Test
-    public void shouldReturnRoleWhenRoleIdExists() {
+    void shouldReturnRoleWhenRoleIdExists() {
         Role developerRole = DEVELOPER_ROLE();
         when(roleRepository.findById(developerRole.getId())).thenReturn(Optional.of(developerRole));
 
@@ -72,7 +73,7 @@ class RolesServiceTest {
     }
 
     @Test
-    public void shouldFailToGetRoleWhenRoleIdDoesNotExist() {
+    void shouldFailToGetRoleWhenRoleIdDoesNotExist() {
         ResourceNotFoundException exception = assertThrows(ResourceNotFoundException.class,
                 () -> rolesService.getRole(UUID_1));
 
@@ -80,7 +81,7 @@ class RolesServiceTest {
     }
 
     @Test
-    public void shouldGetRoleByUserIdAndTeamIdWhenExists() {
+    void shouldGetRoleByUserIdAndTeamIdWhenExists() {
         Membership gianniDeveloper = TestData.DEFAULT_MEMBERSHIP();
         List<Membership> memberships = new ArrayList<Membership>();
         memberships.add(gianniDeveloper);
@@ -100,7 +101,7 @@ class RolesServiceTest {
     }
 
     @Test
-    public void shouldGetMoreThanOneRoleByUserIdAndTeamIdWhenExists() {
+    void shouldGetMoreThanOneRoleByUserIdAndTeamIdWhenExists() {
         Membership gianniDeveloper = TestData.DEFAULT_MEMBERSHIP();
         Membership gianniTester = TestData.GIANNI_TESTER_MEMBERSHIP();
         List<Membership> memberships = new ArrayList<Membership>();
@@ -118,13 +119,13 @@ class RolesServiceTest {
                         gianniDeveloper.getTeamId());
 
         assertNotNull(returnedRoles);
-        assertEquals(returnedRoles.size(), 2);
+        assertThat(returnedRoles).hasSize(2);
         assertEquals(returnedRoles.get(0).getName(), gianniDeveloper.getRole().getName());
         assertEquals(returnedRoles.get(1).getName(), gianniTester.getRole().getName());
     }
 
     @Test
-    public void shouldThrowExceptionWhenUserDoesNotHaveRoleInATeam() {
+    void shouldThrowExceptionWhenUserDoesNotHaveRoleInATeam() {
         List<Membership> memberships = new ArrayList<Membership>();
 
         when(membershipRepository.findByUserIdAndTeamId(

--- a/src/test/java/com/ecore/roles/service/RolesServiceTest.java
+++ b/src/test/java/com/ecore/roles/service/RolesServiceTest.java
@@ -19,8 +19,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
 import static java.lang.String.format;
-
-import static com.ecore.roles.MessageUtil.S_NOT_FOUND;
+import static com.ecore.roles.utils.MessageUtil.S_NOT_FOUND;
 import static com.ecore.roles.utils.TestData.DEVELOPER_ROLE;
 import static com.ecore.roles.utils.TestData.UUID_1;
 import static org.junit.jupiter.api.Assertions.assertEquals;

--- a/src/test/java/com/ecore/roles/service/RolesServiceTest.java
+++ b/src/test/java/com/ecore/roles/service/RolesServiceTest.java
@@ -18,10 +18,11 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
+import static java.lang.String.format;
 
+import static com.ecore.roles.MessageUtil.S_NOT_FOUND;
 import static com.ecore.roles.utils.TestData.DEVELOPER_ROLE;
 import static com.ecore.roles.utils.TestData.UUID_1;
-import static java.lang.String.format;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
@@ -137,6 +138,6 @@ class RolesServiceTest {
                         TestData.GIANNI_USER_UUID,
                         TestData.ORDINARY_CORAL_LYNX_TEAM_UUID));
 
-        assertEquals("Role null not found", exception.getMessage());
+        assertEquals(format(S_NOT_FOUND, Role.class.getSimpleName()), exception.getMessage());
     }
 }

--- a/src/test/java/com/ecore/roles/service/TeamsServiceTest.java
+++ b/src/test/java/com/ecore/roles/service/TeamsServiceTest.java
@@ -22,7 +22,6 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.when;
 
-import java.util.Optional;
 import java.util.UUID;
 
 @ExtendWith(MockitoExtension.class)

--- a/src/test/java/com/ecore/roles/service/TeamsServiceTest.java
+++ b/src/test/java/com/ecore/roles/service/TeamsServiceTest.java
@@ -2,7 +2,10 @@ package com.ecore.roles.service;
 
 import com.ecore.roles.client.TeamsClient;
 import com.ecore.roles.client.model.Team;
+import com.ecore.roles.exception.ResourceNotFoundException;
 import com.ecore.roles.service.impl.TeamsServiceImpl;
+import com.ecore.roles.utils.TestData;
+
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
@@ -13,24 +16,62 @@ import org.springframework.http.ResponseEntity;
 
 import static com.ecore.roles.utils.TestData.ORDINARY_CORAL_LYNX_TEAM;
 import static com.ecore.roles.utils.TestData.ORDINARY_CORAL_LYNX_TEAM_UUID;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.when;
+
+import java.util.Optional;
+import java.util.UUID;
 
 @ExtendWith(MockitoExtension.class)
 class TeamsServiceTest {
 
     @InjectMocks
-    private TeamsServiceImpl TeamsService;
+    private TeamsServiceImpl teamsService;
     @Mock
-    private TeamsClient TeamsClient;
+    private TeamsClient teamsClient;
 
     @Test
     void shouldGetTeamWhenTeamIdExists() {
         Team ordinaryCoralLynxTeam = ORDINARY_CORAL_LYNX_TEAM();
-        when(TeamsClient.getTeam(ORDINARY_CORAL_LYNX_TEAM_UUID))
+        when(teamsClient.getTeam(ORDINARY_CORAL_LYNX_TEAM_UUID))
                 .thenReturn(ResponseEntity
                         .status(HttpStatus.OK)
                         .body(ordinaryCoralLynxTeam));
-        assertNotNull(TeamsService.getTeam(ORDINARY_CORAL_LYNX_TEAM_UUID));
+        assertNotNull(teamsService.getTeam(ORDINARY_CORAL_LYNX_TEAM_UUID));
+    }
+
+    @Test
+    void shouldReturnTrueIfUserIsMemberOfTeam() {
+        Team ordinaryCoralLynxTeam = ORDINARY_CORAL_LYNX_TEAM();
+        when(teamsClient.getTeam(ORDINARY_CORAL_LYNX_TEAM_UUID))
+                .thenReturn(ResponseEntity
+                        .status(HttpStatus.OK)
+                        .body(ordinaryCoralLynxTeam));
+        assertTrue(teamsService.isMemberOfTeam(ORDINARY_CORAL_LYNX_TEAM_UUID, TestData.UUID_2));
+    }
+
+    @Test
+    void shouldReturnFalseIfUserIsNotMemberOfTeam() {
+        Team ordinaryCoralLynxTeam = ORDINARY_CORAL_LYNX_TEAM();
+        when(teamsClient.getTeam(ORDINARY_CORAL_LYNX_TEAM_UUID))
+                .thenReturn(ResponseEntity
+                        .status(HttpStatus.OK)
+                        .body(ordinaryCoralLynxTeam));
+        assertFalse(teamsService.isMemberOfTeam(ORDINARY_CORAL_LYNX_TEAM_UUID, TestData.UUID_4));
+    }
+
+    @Test
+    void shouldThrowExceptionIfTeamDoesNotExist() {
+        UUID fakeTeamId = TestData.UUID_1;
+        when(teamsClient.getTeam(fakeTeamId))
+                .thenReturn(ResponseEntity
+                        .status(HttpStatus.OK)
+                        .body(null));
+        assertThrows(ResourceNotFoundException.class, () -> {
+            teamsService.isMemberOfTeam(fakeTeamId, TestData.UUID_4);
+        });
     }
 }

--- a/src/test/java/com/ecore/roles/utils/MockUtils.java
+++ b/src/test/java/com/ecore/roles/utils/MockUtils.java
@@ -4,6 +4,8 @@ import com.ecore.roles.client.model.Team;
 import com.ecore.roles.client.model.User;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
+
+import org.springframework.core.env.Environment;
 import org.springframework.http.HttpMethod;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
@@ -18,9 +20,13 @@ import static org.springframework.test.web.client.response.MockRestResponseCreat
 
 public class MockUtils {
 
-    public static void mockGetUserById(MockRestServiceServer mockServer, UUID userId, User user) {
+    public static void mockGetUserById(
+            MockRestServiceServer mockServer,
+            UUID userId,
+            User user,
+            Environment env) {
         try {
-            mockServer.expect(requestTo("http://test.com/users/" + userId))
+            mockServer.expect(requestTo(env.getProperty("clients.users-api-host") + "/users/" + userId))
                     .andExpect(method(HttpMethod.GET))
                     .andRespond(
                             withStatus(HttpStatus.OK)
@@ -31,9 +37,15 @@ public class MockUtils {
         }
     }
 
-    public static void mockGetTeamById(MockRestServiceServer mockServer, UUID teamId, Team team) {
+    public static void mockGetTeamById(
+            MockRestServiceServer mockServer,
+            UUID teamId,
+            Team team,
+            Environment env) {
         try {
-            mockServer.expect(ExpectedCount.manyTimes(), requestTo("http://test.com/teams/" + teamId))
+            mockServer.expect(
+                    ExpectedCount.manyTimes(),
+                    requestTo(env.getProperty("clients.teams-api-host") + "/" + teamId))
                     .andExpect(method(HttpMethod.GET))
                     .andRespond(
                             withStatus(HttpStatus.OK)

--- a/src/test/java/com/ecore/roles/utils/RestAssuredHelper.java
+++ b/src/test/java/com/ecore/roles/utils/RestAssuredHelper.java
@@ -11,6 +11,7 @@ import io.restassured.response.Response;
 import io.restassured.response.ValidatableResponse;
 import io.restassured.specification.RequestSpecification;
 import org.hamcrest.Matchers;
+import org.springframework.http.HttpStatus;
 
 import java.util.UUID;
 
@@ -19,6 +20,11 @@ import static io.restassured.RestAssured.when;
 import static io.restassured.http.ContentType.JSON;
 
 public class RestAssuredHelper {
+
+    public static final int HTTP_BAD_REQUEST = HttpStatus.BAD_REQUEST.value();
+    public static final int HTTP_NOT_FOUND = HttpStatus.NOT_FOUND.value();
+    public static final int HTTP_CREATED = HttpStatus.CREATED.value();
+    public static final int HTTP_OK = HttpStatus.OK.value();
 
     public static void setUp(int port) {
         RestAssured.reset();

--- a/src/test/java/com/ecore/roles/utils/TestData.java
+++ b/src/test/java/com/ecore/roles/utils/TestData.java
@@ -27,6 +27,9 @@ public class TestData {
     public static final UUID DEFAULT_MEMBERSHIP_UUID =
             UUID.fromString("98de61a0-b9e3-11ec-8422-0242ac120002");
 
+    public static final UUID GIANNI_TESTER_MEMBERSHIP_UUID =
+            UUID.fromString("d4a64711-3a00-4537-8ee6-3cb538a5d98f");
+
     public static Role DEVELOPER_ROLE() {
         return Role.builder()
                 .id(DEVELOPER_ROLE_UUID)
@@ -86,6 +89,15 @@ public class TestData {
         return Membership.builder()
                 .id(DEFAULT_MEMBERSHIP_UUID)
                 .role(DEVELOPER_ROLE())
+                .userId(GIANNI_USER_UUID)
+                .teamId(ORDINARY_CORAL_LYNX_TEAM_UUID)
+                .build();
+    }
+
+    public static Membership GIANNI_TESTER_MEMBERSHIP() {
+        return Membership.builder()
+                .id(GIANNI_TESTER_MEMBERSHIP_UUID)
+                .role(TESTER_ROLE())
                 .userId(GIANNI_USER_UUID)
                 .teamId(ORDINARY_CORAL_LYNX_TEAM_UUID)
                 .build();

--- a/src/test/java/com/ecore/roles/utils/TestData.java
+++ b/src/test/java/com/ecore/roles/utils/TestData.java
@@ -100,4 +100,16 @@ public class TestData {
                 .build();
     }
 
+    public static Membership NEW_MEMBERSHIP(boolean buildWithId) {
+        Membership m = Membership.builder()
+                .role(DEVELOPER_ROLE())
+                .userId(UUID_3)
+                .teamId(ORDINARY_CORAL_LYNX_TEAM_UUID)
+                .build();
+        if (buildWithId) {
+            m.setId(DEFAULT_MEMBERSHIP_UUID);
+        }
+        return m;
+    }
+
 }

--- a/target/.gitignore
+++ b/target/.gitignore
@@ -1,2 +1,0 @@
-/classes/
-/test-classes/


### PR DESCRIPTION
### e-core Backend Code Challenge

Hi there!

This is the PR solution for e-core Backend Challenge as described in the email attachment. All project updates are described below. If anything is unclear or if you need further information, please do not hesitate to reach out.

Best regards,
**Andre Muniz**

**New feature approach:** 
Considering the new requirement to get a list of roles a member can have in a team, the code has to be updated to allow a userId to be assigned more roles in a given teamId. For example, a member could be a developer and a tester at the same time in a team. The database constraint is already set as expected     "constraint ... unique (role_id, team_id, user_id)", allowing the system to insert more than one role for a user in a team, so the new feature will change only the java code.

**Removal of unused method:**
There was an unused private method getDefaultRole in RolesServiceImpl, which made me think if I should consider returning the "Developer" role as the default when no role was found for a member of a team. But since there was no specification about this business rule, I decided to remove that unused private method from the class. In that case, when a team member has no role registered in the database, then the new API endpoint will return a 404 status, meaning that no resource was found for the input parameters.

**Logging:**
Although there were two classes with @Log4j2 annotation, none of them were making calls for the log object. No class in the whole project was making any single log. I know that logging is crucial for supporting and monitoring any application, so I decided to keep the annotations as the original project because there might be a real chance for them to be used in this project.

**The serializable interface of exceptions:**
No serial version field is declared in the exceptions, so they are using the default value from Java. In case these classes need to be serialized, maybe giving them a custom serial version Id field would be a good idea. Since there was no specification about this in the email, I decided to leave them without declaring a serial version field.

**List of commit messages, containing all code changes:**

[ecore 001] Fix RolesService Interface methods' names.

[ecore 002] Fix MembershipsRestController

	- refactor 'produces = "application/json"' annotation parameter do class level.
	- fix HTTP method api getMemberships from POST do GET, according to restful pattern.
	
[ecore 003] Fix RolesRestController

	- refactor 'produces = "application/json"' annotation parameter do class level.
	- fix HTTP method api getRoles from POST do GET, according to restful pattern.
	
[ecore 004] Fix TeamsRestController

	- refactor 'produces = "application/json"' annotation parameter do class level.
	- fix HTTP method api getTeams from POST do GET, according to restful pattern.
	- fix HTTP method api getTeam from POST do GET, according to restful pattern.

[ecore 005] Fix UsersRestController

	- refactor 'produces = "application/json"' annotation parameter do class level.
	- fix HTTP method api getUsers from POST do GET, according to restful pattern.
	- fix HTTP method api getUser from POST do GET, according to restful pattern.

[ecore 006] Fix MembershipsRestController

	- changed HTTP return status of assignRoleToMembership from 200 to 201, according to restful pattern
	- using HttpStatus enumeration to assign HTTP return status of endpoints, instead of "magic numbers".

[ecore 007] Fix test failed shouldFailToAssignRoleWhenMembershipIsInvalid

	- added new valitation to method MembershipsServiceImpl.assignRoleToMembership to check if given userId is member of team lead of providade team.
	- added new method isMemberOfTeam to TeamsService interface.
	- added new method implementation in TeamsServiceImpl for isMemberOfTeam method .
	- changed DefaultExceptionHandler class to use HttpStatus enumeration instead of "magic numbers".
	- added new constructor for InvalidArgumentException class in order to pass additional information for the exception message.
	- using HttpStatus enumeration to ensure HTTP return status of tests, instead of "magic numbers".
	
[ecore 008] Fix test shouldCreateNewRole

	- changed HTTP return status of createRole from 200 to HttpStatus.CREATED (201), according to restful pattern and as expected by the test.
	- using HttpStatus enumeration to ensure HTTP return status of tests, instead of "magic numbers", by creating new static constants in RestAssuredHelper.
	- using newly created constants from RestAssuredHelper in both MembershipsApiTests and RolesApiTest classes.
	
[ecore 009] Added new tests to TeamsServiceTest class

	- in order to properly test the new isMemberOfTeam method, 3 new test cases were created:
	* shouldReturnTrueIfUserIsMemberOfTeam
	* shouldReturnFalseIfUserIsNotMemberOfTeam
	* shouldThrowExceptionIfTeamDoesNotExist
	- refactoring bad variable names.

[ecore 010] Fix test shouldCreateMembership

	- created new test data with membership to be created, because the previous one was rasing ResourceExistsException.
	- fixed the code in shouldCreateMembership to reflect new scenario.

[ecore 011] New API endpoint to get a list of Roles

	- RolesApi: added new method getRoles(UUID userId, UUID teamId);
	- RolesRestController: added new api endpoint implementation for method getRoles;
	- RolesService: added new method getRoles(UUID userId, UUID teamId);
	- RolesServiceImpl: added implementation for new method getRoles;
	- RolesServiceImpl: removed unused private method getDefaultRole;
	- Membership: updated unique constraint do columns {"role_id", "team_id", "user_id"};
	- MembershipRepository: changed return type of findByUserIdAndTeamId to List<Membership>;
	- MembershipRepository: added new method findByRoleIdAndUserIdAndTeamId to return a unique membership;
	- MembershipsServiceImpl: changed the validation to check if the membership already exists to use the new method findByRoleIdAndUserIdAndTeamId from MembershipRepository;
	- MembershipsServiceTest: updated the tests shouldCreateMembership and shouldFailToCreateMembershipWhenItExists to reflect the new behavior of previously existing methods;
	- More info will be given in the PR.

[ecore 012] Fix RolesApiTest to reflect newly created endpoint

	- shouldGetRoleByUserIdAndTeamId: changed expected result to match a list instead of a unique Role;
	- shouldFailToGetRoleByUserIdAndTeamIdWhenItDoesNotExist: changed expected error message to match new one.


[ecore 013] New tests for new feature of getting a list of Roles

	- RolesApiTest: new test shouldGetMoreThanOneRoleByUserIdAndTeamId to check if endpoint is capable of returning more than one role if the member has at least two memberships in a given team;
	- RolesServiceTest: new test shouldGetRoleByUserIdAndTeamIdWhenExists to check if service method is capable of returning exactly one role if the member has one membership in a given team;
	- RolesServiceTest: new test shouldGetMoreThanOneRoleByUserIdAndTeamIdWhenExists to check if service method is capable of returning more than one role if the member has at least two memberships in a given team;
	- RolesServiceTest: new test shouldThrowExceptionWhenUserDoesNotHaveRoleInATeam to check if service method is capable of throwing a ResourceNotFoundException when the user has no Role in the given team;
	- MembershipsServiceTest: formatting;
	- TestData: added some new fake data to use in new tests.


[ecore 014] General refactoring to improve code quality

	- Created new class MessageUtil to organize string messages within the project;
	- Changed classes and tests to use MessageUtil;
	- Using environment properties from src/test/resources/application.yml in unit tests;
	

[ecore 015] General refactoring according to SonarQube standard rules

[ecore 016] Moved class MessageUtil do package com.ecore.roles.utils

[ecore 017] Added spotless:apply to build stage in Dockerfile